### PR TITLE
reset session state of search button after logging out

### DIFF
--- a/Views/CustomerViews/FollowCastMemberView.py
+++ b/Views/CustomerViews/FollowCastMemberView.py
@@ -47,5 +47,6 @@ def follow_cast_member_view() -> None:
         end_session(cache.session)
         cache.user = None
         cache.session = None
+        st.session_state.search_button = False
         cache.view = 'login_view'
         st.experimental_rerun()

--- a/Views/CustomerViews/MovieInfoView.py
+++ b/Views/CustomerViews/MovieInfoView.py
@@ -57,5 +57,6 @@ def movie_info_view() -> None:
         end_session(cache.session)
         cache.user = None
         cache.session = None
+        st.session_state.search_button = False
         cache.view = 'login_view'
         st.experimental_rerun()

--- a/Views/CustomerViews/MovieSearchView.py
+++ b/Views/CustomerViews/MovieSearchView.py
@@ -33,6 +33,7 @@ def movie_search_view() -> None:
         end_session(cache.session)
         cache.user = None
         cache.session = None
+        st.session_state.search_button = False
         cache.view = 'login_view'
         st.experimental_rerun()
 

--- a/Views/CustomerViews/WatchMovieView.py
+++ b/Views/CustomerViews/WatchMovieView.py
@@ -36,5 +36,6 @@ def watch_movie_view() -> None:
         end_session(cache.session)
         cache.user = None
         cache.session = None
+        st.session_state.search_button = False
         cache.view = 'login_view'
         st.experimental_rerun()


### PR DESCRIPTION
scenario: a user logged in, searched for a movie, and logged out. Another user then logs in and searches for a different movie, but the view is still displaying the results of the previous search because it hasn't been cleared.

solution: reset the session state of the search button after logging out.